### PR TITLE
Avoid width and link record within centerlanes

### DIFF
--- a/scenariogeneration/xodr/generators.py
+++ b/scenariogeneration/xodr/generators.py
@@ -332,7 +332,7 @@ def _create_junction_links(connection, nlanes,r_or_l,sign,from_offset=0,to_offse
         connection.add_lanelink( r_or_l*i+from_offset, r_or_l*sign*i+to_offset)
 
 
-def create_junction(junction_roads, id, roads):
+def create_junction(junction_roads, id, roads, name='my junction'):
     """ create_junction creates the junction struct for a set of roads
 
 
@@ -343,6 +343,9 @@ def create_junction(junction_roads, id, roads):
             id (int): the id of the junction
             
             roads (list of Road): all incomming roads to the junction
+            
+            name(str): name of the junction
+            default: 'my junction'
 
         Returns
         -------
@@ -352,7 +355,7 @@ def create_junction(junction_roads, id, roads):
 
 
 
-    junc = Junction('my junction',id)
+    junc = Junction(name,id)
     
     for jr in junction_roads:
         # handle succesor lanes

--- a/scenariogeneration/xodr/lane.py
+++ b/scenariogeneration/xodr/lane.py
@@ -280,10 +280,12 @@ class Lane():
         self.links.add_link(_Link(link_type,str(id)))
 
     def _set_lane_id(self,lane_id):
-        """ set the lane id of the lane
+        """ set the lane id of the lane and set lane type to 'none' in case of centerlane
 
         """
         self.lane_id = lane_id
+        if self.lane_id == 0:
+            self.lane_type = LaneType.none
 
     def add_roadmark(self,roadmark):
         """ add_roadmark adds a roadmark to the lane

--- a/scenariogeneration/xodr/lane.py
+++ b/scenariogeneration/xodr/lane.py
@@ -238,16 +238,16 @@ class Lane():
             lane_type (LaneType): type of lane
                 Default: LaneType.driving
 
-            a (float): a coefficient
+            a (float): a polynomial coefficient for width (left/right) or laneoffset (center)
                 Default: 0
 
-            b (float): b coefficient
+            b (float): b polynomial coefficient for width (left/right) or laneoffset (center)
                 Default: 0
 
-            c (float): c coefficient
+            c (float): c polynomial coefficient for width (left/right) or laneoffset (center)
                 Default: 0
 
-            d (float): d coefficient
+            d (float): d polynomial coefficient for width (left/right) or laneoffset (center)
                 Default: 0
 
             soffset (float): soffset of lane
@@ -339,17 +339,22 @@ class Lane():
         """
         element = ET.Element('lane',attrib=self.get_attributes())
                 
+        #polynomial dict either for width (left/right lanes) or laneOffset (center lane)
+        polynomialdict = {}
+        polynomialdict['a'] = str(self.a)
+        polynomialdict['b'] = str(self.b)
+        polynomialdict['c'] = str(self.c)
+        polynomialdict['d'] = str(self.d)
+        polynomialdict['sOffset'] = str(self.soffset) 
+        
         #according to standard if lane is centerlane it should 
-        #not have a width record and omit the link record
+        #not have a width record and omit the link record        
         if self.lane_id != 0: 
             element.append(self.links.get_element())
-            widthdict = {}
-            widthdict['a'] = str(self.a)
-            widthdict['b'] = str(self.b)
-            widthdict['c'] = str(self.c)
-            widthdict['d'] = str(self.d)
-            widthdict['sOffset'] = str(self.soffset) 
-            ET.SubElement(element,'width',attrib=widthdict)
+            ET.SubElement(element,'width',attrib=polynomialdict)        
+        #use polynomial dict for laneOffset in case of center lane (only if values provided)
+        elif any([self.a,self.b,self.c,self.d]):            
+            ET.SubElement(element,'laneOffset',attrib=polynomialdict)                         
             
         if self.roadmark:
             element.append(self.roadmark.get_element())

--- a/scenariogeneration/xodr/lane.py
+++ b/scenariogeneration/xodr/lane.py
@@ -338,16 +338,19 @@ class Lane():
 
         """
         element = ET.Element('lane',attrib=self.get_attributes())
-        element.append(self.links.get_element())
-
-        widthdict = {}
-        widthdict['a'] = str(self.a)
-        widthdict['b'] = str(self.b)
-        widthdict['c'] = str(self.c)
-        widthdict['d'] = str(self.d)
-        widthdict['sOffset'] = str(self.soffset)
-
-        ET.SubElement(element,'width',attrib=widthdict)
+                
+        #according to standard if lane is centerlane it should 
+        #not have a width record and omit the link record
+        if self.lane_id != 0: 
+            element.append(self.links.get_element())
+            widthdict = {}
+            widthdict['a'] = str(self.a)
+            widthdict['b'] = str(self.b)
+            widthdict['c'] = str(self.c)
+            widthdict['d'] = str(self.d)
+            widthdict['sOffset'] = str(self.soffset) 
+            ET.SubElement(element,'width',attrib=widthdict)
+            
         if self.roadmark:
             element.append(self.roadmark.get_element())
             

--- a/scenariogeneration/xodr/lane.py
+++ b/scenariogeneration/xodr/lane.py
@@ -250,7 +250,7 @@ class Lane():
             d (float): d polynomial coefficient for width (left/right) or laneoffset (center)
                 Default: 0
 
-            soffset (float): soffset of lane
+            soffset (float): soffset of lane renamed to s in case of centerlane
                 Default: 0
 
         """ 
@@ -355,7 +355,8 @@ class Lane():
             element.append(self.links.get_element())
             ET.SubElement(element,'width',attrib=polynomialdict)        
         #use polynomial dict for laneOffset in case of center lane (only if values provided)
-        elif any([self.a,self.b,self.c,self.d]):            
+        elif any([self.a,self.b,self.c,self.d]):
+            polynomialdict['s'] = polynomialdict.pop('sOffset')            
             ET.SubElement(element,'laneOffset',attrib=polynomialdict)                         
             
         if self.roadmark:


### PR DESCRIPTION
- according to standard width shall not be provided as a record for centerlanes
- also link record can be dropped as they are not linked