### PR TITLE
Use spaces instead of tabs for indenting XML files

### DIFF
--- a/scenariogeneration/helpers.py
+++ b/scenariogeneration/helpers.py
@@ -138,7 +138,7 @@ def prettyprint(element):
         element = element.get_element()
     rough = ET.tostring(element, 'utf-8')
     reparsed = mini.parseString(rough)
-    print(reparsed.toprettyxml(indent="\t"))
+    print(reparsed.toprettyxml(indent="    "))
 
 
 

--- a/scenariogeneration/xodr/helpers.py
+++ b/scenariogeneration/xodr/helpers.py
@@ -34,7 +34,7 @@ def printToFile(element,filename,prettyprint=True):
     if prettyprint:    
         rough = ET.tostring(element,'utf-8').replace(b'\n',b'').replace(b'\t',b'')
         reparsed = mini.parseString(rough)
-        towrite = reparsed.toprettyxml(indent="\t")
+        towrite = reparsed.toprettyxml(indent="    ")
         with open(filename,'w') as file_handle:
             file_handle.write(towrite)
     else:

--- a/scenariogeneration/xosc/helpers.py
+++ b/scenariogeneration/xosc/helpers.py
@@ -20,7 +20,7 @@ def printToFile(element, filename, prettyprint=True):
     if prettyprint:
         rough = ET.tostring(element, 'utf-8').replace(b'\n', b'').replace(b'\t', b'')
         reparsed = mini.parseString(rough)
-        towrite = reparsed.toprettyxml(indent="\t")
+        towrite = reparsed.toprettyxml(indent="    ")
         with open(filename, "w") as file_handle:
             file_handle.write(towrite)
     else:


### PR DESCRIPTION
Since most of the code base uses spaces and most projects use spaces nowadays I
believe this is a reasonable change.e.