### PR TITLE
Fix self.fixed not always set for fixed start point

### DIFF
--- a/scenariogeneration/xodr/geometry.py
+++ b/scenariogeneration/xodr/geometry.py
@@ -162,7 +162,6 @@ class PlanView():
         self.fixed = False
         if all([x_start != None, y_start!=None,h_start!=None]):
             self.set_start_point(x_start, y_start, h_start)
-            self.fixed = True
         elif any([x_start != None, y_start!=None,h_start!=None]):
             raise NotEnoughInputArguments('If a start position is wanted for the PlanView, all inputs must be used.')
 
@@ -214,6 +213,7 @@ class PlanView():
         self.present_x = x_start
         self.present_y = y_start
         self.present_h = h_start
+        self.fixed = True
 
     def get_start_point(self):
         """ returns the start point of the planview


### PR DESCRIPTION
When set_start_point() is called  manually instead of using the constructor then the fixed flag is not set. This leads to a crash during export. It makes more sense to set the flag inside set_start_point() because setting the start point and setting the fixed label is essentially the same. If I am not missing anything then they are redundant. Therefore, one could also remove the self.fixed variable altogether and just check if the start point has been set. This would probably lead to less bugs.