### PR TITLE
Rename variable for consistency, fix typo

### DIFF
--- a/scenariogeneration/xosc/scenario.py
+++ b/scenariogeneration/xosc/scenario.py
@@ -113,13 +113,13 @@ class RoadNetwork():
         ----------
             roadfile (str): path to the opendrive file
 
-            scenegraph (str): path to the opensceengraph file (optional)
+            scenegraph (str): path to the openscenegraph file (optional)
 
         Attributes
         ----------
             road_file (str): path to the opendrive file
 
-            scene (str): path to the opensceengraph file 
+            scenegraph_file (str): path to the openscenegraph file 
 
             traffic_signals (list of TrafficSignalController): all traffic signals in the roadnetwork
             
@@ -131,18 +131,18 @@ class RoadNetwork():
 
 
     """
-    def __init__(self,roadfile,scenegraph=None):
+    def __init__(self,roadfile,scenegraphfile=None):
         """ Initalizes the RoadNetwork
 
         Parameters
         ----------
             roadfile (str): path to the opendrive file
 
-            scenegraph (str): path to the opensceengraph file (optional)
+            scenegraphfile (str): path to the openscenegraph file (optional)
 
         """
         self.road_file = roadfile
-        self.scene = scenegraph
+        self.scenegraph_file = scenegraphfile
         self.traffic_signals = []
 
     def add_traffic_signal_controller(self,traffic_signal_controller):
@@ -163,8 +163,8 @@ class RoadNetwork():
         """
         roadnetwork = ET.Element('RoadNetwork')
         ET.SubElement(roadnetwork,'LogicFile',{'filepath': self.road_file})
-        if self.scene:
-            ET.SubElement(roadnetwork,'SceneGraphFile',{'filepath':self.scene})
+        if self.scenegraph_file:
+            ET.SubElement(roadnetwork,'SceneGraphFile',{'filepath':self.scenegraph_file})
         if self.traffic_signals:
             trafsign_element = ET.SubElement(roadnetwork,'TrafficSignals')
             for ts in self.traffic_signals:


### PR DESCRIPTION
Rename "scene" to "scenegraph_file" to have it consistent with "road_file".