### PR TITLE
Change elements order; fulfill required sequence

### DIFF
--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -451,6 +451,8 @@ class Road():
             for r in self.types:
                 element.append(r.get_element())
         element.append(self.planview.get_element())
+        element.append(self.elevationprofile.get_element())
+        element.append(self.lateralprofile.get_element())
         element.append(self.lanes.get_element())
         if len(self.signals) > 0:
             signalselement = ET.SubElement(element,'signals')
@@ -460,8 +462,6 @@ class Road():
             objectselement = ET.SubElement(element,'objects')
             for road_object in self.objects:
                 objectselement.append(road_object.get_element())        
-        element.append(self.elevationprofile.get_element())
-        element.append(self.lateralprofile.get_element())
         return element
 
 class OpenDrive():


### PR DESCRIPTION
The OpenDrive XSD requires a "sequence" to be followed
for adding lateralProfile and elevationProfile into
a bigger set of elements. This was not followed before
therefore the linting of generated xodr files failed.
This change should resolve that issue.

Note: esmini accepted the incorrect sequence as well