### PR TITLE
Fix install dependency resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'scipy',
-        'pyclothoids'
+        'pyclothoids',
+        'attrs'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
I believe `attrs` is probably not really necessary in the end and it would be better to stay low on additional dependencies in order to facilitate integration of the library into other projects. However, if the dependency can not be removed then this line should be added.