### PR TITLE
Fix typos: vehcile -> vehicle, it -> its

### DIFF
--- a/examples/xosc/Acceleration_condition.py
+++ b/examples/xosc/Acceleration_condition.py
@@ -1,6 +1,6 @@
-""" 
-    Example showing how one vehicle triggers based on the acceleration of another vehcile, then changes it speed.
-    
+"""
+    Example showing how one vehicle triggers based on the acceleration of another vehicle, then changes its speed.
+
 
     Some features used:
 
@@ -11,11 +11,11 @@
     - RelativeRoadPosition
 
     - AbsoluteSpeedAction
-        
-    
+
+
 """
 import os
-from scenariogeneration import xosc, prettyprint  
+from scenariogeneration import xosc, prettyprint
 
 ### create catalogs
 catalog = xosc.Catalog()

--- a/examples/xosc/ParameterValueDistribution.py
+++ b/examples/xosc/ParameterValueDistribution.py
@@ -1,6 +1,6 @@
-""" 
-    Example showing how one vehicle triggers based on the acceleration of another vehcile, then changes it speed.
-    
+"""
+    Example showing how one vehicle triggers based on the acceleration of another vehicle, then changes its speed.
+
     Some features used:
 
     - ParameterValueDistribution
@@ -10,12 +10,12 @@
     - NormalDistribution
 
     - Histogram
-        
+
 """
 import os
-from scenariogeneration import xosc, prettyprint  
+from scenariogeneration import xosc, prettyprint
 
-# some names used in both scenario and 
+# some names used in both scenario and
 scenario_filename = 'base_scenario.xosc'
 ego_param_name = '$egospeed'
 target_param_name = '$targetspeed'
@@ -72,7 +72,7 @@ stoc = xosc.Stochastic(50,1.234)
 nd = xosc.NormalDistribution(25,1)
 stoc.add_distribution(ego_param_name,nd)
 
-## add a histogram for the target 
+## add a histogram for the target
 hg = xosc.Histogram()
 hg.add_bin(0.3,xosc.Range(15,25))
 hg.add_bin(0.7,xosc.Range(25,35))

--- a/examples/xosc/Speed_condition.py
+++ b/examples/xosc/Speed_condition.py
@@ -1,14 +1,14 @@
-""" 
-    Simple example showing how one vehicle triggers based on the speed of another vehcile, then changes it speed
+"""
+    Simple example showing how one vehicle triggers based on the speed of another vehicle, then changes its speed
 
     Some features used:
-    
+
     - SpeedCondition
-    
+
     - AbsoluteSpeedAction
-    
+
     - RoadPosition
-        
+
 """
 import os
 from scenariogeneration import xosc, prettyprint
@@ -87,7 +87,7 @@ action = xosc.AbsoluteSpeedAction(30,sin_time)
 event.add_action('newspeed',action)
 
 
-## create the maneuver 
+## create the maneuver
 man = xosc.Maneuver('my_maneuver')
 man.add_event(event)
 

--- a/examples/xosc/Stop_on_offroad.py
+++ b/examples/xosc/Stop_on_offroad.py
@@ -1,18 +1,18 @@
-""" 
-    Simple example showing how one vehicle triggers based on the speed of another vehcile, then changes it speed
+"""
+    Simple example showing how one vehicle triggers based on the speed of another vehicle, then changes its speed
 
     Some features used:
-    
+
     - SpeedCondition
-    
+
     - AbsoluteSpeedAction
-    
+
     - RoadPosition
-    
+
     - OffroadCondition
 """
 import os
-from scenariogeneration import xosc, prettyprint   
+from scenariogeneration import xosc, prettyprint
 
 ### create catalogs
 catalog = xosc.Catalog()
@@ -88,7 +88,7 @@ action = xosc.RelativeLaneChangeAction(-8,targetname,xosc.TransitionDynamics(xos
 event.add_action('newspeed',action)
 
 
-## create the maneuver 
+## create the maneuver
 man = xosc.Maneuver('my_maneuver')
 man.add_event(event)
 


### PR DESCRIPTION
Fixing two typos (multiplied by copy-paste) in the modules docstrings of some python files that also goes into the generated documentation.

My formatting script also cleared some trialing whitespace on save, so I figured I might as well include those changes as well. Let me know if you think differently, and I'll revert those changes :)

Thanks!