### PR TITLE
Fix lane linking from IDs

### DIFF
--- a/examples/xodr/road_link_unequal_number_of_lanes.py
+++ b/examples/xodr/road_link_unequal_number_of_lanes.py
@@ -1,0 +1,42 @@
+""" Example for linking two roads with an unequal number of lanes.
+
+Note: This is possible and valid according to the OpenDRIVE standard. It is
+sometimes necessary to use this approach but it might often be prefered to begin
+a new lane section to change the number of lanes instead.
+"""
+
+from scenariogeneration import xodr
+import os
+
+# Create roads
+length_road = 100.0
+road_first = xodr.create_road([xodr.Line(length_road)], 1, 2, 3)
+road_second = xodr.create_road([xodr.Line(length_road)], 2, 2, 4)
+# Make a new lane open up/branch out
+new_lane_width = 3.0
+road_second.lanes.lanesections[0].rightlanes[2].a = 0.0
+road_second.lanes.lanesections[0].rightlanes[2].b = 0.0
+road_second.lanes.lanesections[0].rightlanes[2].c = 3.0/length_road**2 * new_lane_width
+road_second.lanes.lanesections[0].rightlanes[2].d = -2.0/length_road**3 * new_lane_width
+
+## Create the OpenDrive class (Master class)
+odr = xodr.OpenDrive('myroads')
+
+## Finally add roads to Opendrive
+odr.add_road(road_first)
+odr.add_road(road_second)
+
+# Link roads
+road_first.add_successor(xodr.ElementType.road, 2, xodr.ContactPoint.start)
+road_second.add_predecessor(xodr.ElementType.road, 1, xodr.ContactPoint.end)
+
+# Link lanes but do not link the newly beginning lane
+link_lane_ids_first = [2,1,-1,-2,-3]
+link_lane_ids_second = [2,1,-1,-2,-4]
+xodr.create_lane_links_from_ids(road_first, road_second, link_lane_ids_first, link_lane_ids_second)
+
+# Adjust initial positions of the roads looking at succ-pred logic
+odr.adjust_startpoints()
+
+# write the OpenDRIVE file as xodr using current script name
+odr.write_xml(os.path.basename(__file__).replace('.py', '.xodr'))

--- a/scenariogeneration/xodr/links.py
+++ b/scenariogeneration/xodr/links.py
@@ -391,7 +391,7 @@ class Connection:
         ----------
             in_lane: lane id of the incoming road
 
-            out_lane: land id of the outgoing road
+            out_lane: lane id of the outgoing road
         """
         self.links.append((in_lane, out_lane))
         return self
@@ -654,9 +654,14 @@ def are_roads_connected(road1, road2):
     return False, ""
 
 
-def create_lane_links_unequal(road1, road2, road1_land_ids, road2_land_ids):
-    """Experimantal funciton to connect roads with hardcoded lane numbers
-    NOTE: only use this when you have don't have the same amount of lanes between the edge of two roads
+def create_lane_links_from_ids(road1, road2, road1_lane_ids, road2_lane_ids):
+    """
+    Experimental function to connect lanes of two roads given the corresponding lane IDs
+    (numbers).
+
+    NOTE: Usually only necessary when there is not the same amount of lanes at the
+    connection of two roads or there are new lanes with zero width at the beginning of a
+    road.
 
     Parameters
     ----------
@@ -664,15 +669,15 @@ def create_lane_links_unequal(road1, road2, road1_land_ids, road2_land_ids):
 
         road2 (Road): the second road
 
-        road1_land_ids (list of int): list of the ids of road1 (do not use the 0 lane)
+        road1_lane_ids (list of int): list of the ids of road1 (do not use the 0 lane)
 
-        road2_land_ids (list of int): list of the ids of road2 (do not use the 0 lane)
+        road2_lane_ids (list of int): list of the ids of road2 (do not use the 0 lane)
 
     """
-    if len(road1_land_ids) != len(road2_land_ids):
+    if len(road1_lane_ids) != len(road2_lane_ids):
         raise GeneralIssueInputArguments("Length of the lane id lists is not the same.")
 
-    if (0 in road1_land_ids) or (0 in road2_land_ids):
+    if (0 in road1_lane_ids) or (0 in road2_lane_ids):
         raise ValueError("The 0 lane should not be linked.")
 
     if road1.road_type == -1 and road2.road_type == -1:
@@ -683,24 +688,24 @@ def create_lane_links_unequal(road1, road2, road1_land_ids, road2_land_ids):
         second_linktype, _, second_connecting_lanesec = _get_related_lanesection(
             road2, road1
         )
-        for i in range(len(road1_land_ids)):
-            if road1_land_ids[i] < 0:
+        for i in range(len(road1_lane_ids)):
+            if road1_lane_ids[i] < 0:
                 road1.lanes.lanesections[first_connecting_lanesec].rightlanes[
-                    road1_land_ids[i]
-                ].add_link(first_linktype, road2_land_ids[i])
+                    road1_lane_ids[i]
+                ].add_link(first_linktype, road2_lane_ids[i])
             else:
                 road1.lanes.lanesections[first_connecting_lanesec].leftlanes[
-                    road1_land_ids[i]
-                ].add_link(first_linktype, road2_land_ids[i])
+                    road1_lane_ids[i]
+                ].add_link(first_linktype, road2_lane_ids[i])
 
-            if road2_land_ids[i] < 0:
+            if road2_lane_ids[i] < 0:
                 road2.lanes.lanesections[first_connecting_lanesec].rightlanes[
-                    road2_land_ids[i]
-                ].add_link(second_connecting_lanesec, road1_land_ids[i])
+                    road2_lane_ids[i]
+                ].add_link(second_connecting_lanesec, road1_lane_ids[i])
             else:
                 road2.lanes.lanesections[first_connecting_lanesec].leftlanes[
-                    road2_land_ids[i]
-                ].add_link(second_connecting_lanesec, road1_land_ids[i])
+                    road2_lane_ids[i]
+                ].add_link(second_connecting_lanesec, road1_lane_ids[i])
 
     else:
         raise NotImplementedError(

--- a/scenariogeneration/xodr/links.py
+++ b/scenariogeneration/xodr/links.py
@@ -675,10 +675,10 @@ def create_lane_links_from_ids(road1, road2, road1_lane_ids, road2_lane_ids):
 
     """
     if len(road1_lane_ids) != len(road2_lane_ids):
-        raise GeneralIssueInputArguments("Length of the lane id lists is not the same.")
+        raise GeneralIssueInputArguments("Length of the lane ID lists is not the same.")
 
     if (0 in road1_lane_ids) or (0 in road2_lane_ids):
-        raise ValueError("The 0 lane should not be linked.")
+        raise ValueError("The center lane (ID 0) should not be linked.")
 
     if road1.road_type == -1 and road2.road_type == -1:
 
@@ -689,27 +689,25 @@ def create_lane_links_from_ids(road1, road2, road1_lane_ids, road2_lane_ids):
             road2, road1
         )
         for i in range(len(road1_lane_ids)):
-            if road1_lane_ids[i] < 0:
-                road1.lanes.lanesections[first_connecting_lanesec].rightlanes[
-                    road1_lane_ids[i]
-                ].add_link(first_linktype, road2_lane_ids[i])
-            else:
+            if road1_lane_ids[i] > 0:
                 road1.lanes.lanesections[first_connecting_lanesec].leftlanes[
-                    road1_lane_ids[i]
+                    road1_lane_ids[i]-1
                 ].add_link(first_linktype, road2_lane_ids[i])
-
-            if road2_lane_ids[i] < 0:
-                road2.lanes.lanesections[first_connecting_lanesec].rightlanes[
-                    road2_lane_ids[i]
-                ].add_link(second_connecting_lanesec, road1_lane_ids[i])
             else:
-                road2.lanes.lanesections[first_connecting_lanesec].leftlanes[
-                    road2_lane_ids[i]
-                ].add_link(second_connecting_lanesec, road1_lane_ids[i])
-
+                road1.lanes.lanesections[first_connecting_lanesec].rightlanes[
+                    abs(road1_lane_ids[i])-1
+                ].add_link(first_linktype, road2_lane_ids[i])
+            if road2_lane_ids[i] > 0:
+                road2.lanes.lanesections[second_connecting_lanesec].leftlanes[
+                    road2_lane_ids[i]-1
+                ].add_link(second_linktype, road1_lane_ids[i])
+            else:
+                road2.lanes.lanesections[second_connecting_lanesec].rightlanes[
+                    abs(road2_lane_ids[i])-1
+                ].add_link(second_linktype, road1_lane_ids[i])
     else:
         raise NotImplementedError(
-            "linking connecting roads like this is not implemented yet."
+            "This API currently does not support linking with junction connecting roads."
         )
 
 


### PR DESCRIPTION
Here is a bugfix you can hopefully merge.
Was a bit unsure if 
create_lane_links_from_ids() or create_lane_links_by_ids()
is more correct English usage.
In any case I wanted to rename the method since it can be used also for equal number of lanes if someone needs to do that.