### PR TITLE
Consider laneoffsets for adjustment

### DIFF
--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -697,38 +697,65 @@ class OpenDrive:
 
         if neighbour_type == "predecessor":
 
-            if contact_point == ContactPoint.start:
-                x, y, h = self.roads[str(neighbour_id)].planview.get_start_point()
+            if contact_point == ContactPoint.start :    
+                x,y,h = self.roads[str(neighbour_id)].planview.get_start_point()
                 h = (
                     h + np.pi
                 )  # we are attached to the predecessor's start, so road[k] will start in its opposite direction
+                relevant_lanesection = 0
+                relevant_s = 0
             elif contact_point == ContactPoint.end:
-                x, y, h = self.roads[str(neighbour_id)].planview.get_end_point()
+                x,y,h = self.roads[str(neighbour_id)].planview.get_end_point()
+                relevant_lanesection = -1
+                relevant_s = self.roads[str(neighbour_id)].planview.get_total_length()-self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].s
+
             else:
                 raise ValueError("Unknown ContactPoint")
 
             num_lane_offsets = main_road.lane_offset_pred
-            x = -num_lane_offsets * 3 * np.sin(h) + x
-            y = num_lane_offsets * 3 * np.cos(h) + y
+            offset_width = 0
+            #if a lane offset exists, go through relevant lanes to determine width of offset
+            if num_lane_offsets < 0 :
+                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].rightlanes[0:-1*num_lane_offsets]:
+                    offset_width = offset_width - (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
+            if num_lane_offsets > 0 :
+                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].leftlanes[0:num_lane_offsets]:
+                    offset_width = offset_width + lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3
+            x = -offset_width*np.sin(h) + x
+            y = offset_width*np.cos(h) + y
 
-            main_road.planview.set_start_point(x, y, h)
+            main_road.planview.set_start_point(x,y,h)
             main_road.planview.adjust_geometries()
 
         elif neighbour_type == "successor":
 
-            if contact_point == ContactPoint.start:
-                x, y, h = self.roads[str(neighbour_id)].planview.get_start_point()
+            if contact_point == ContactPoint.start:    
+                x,y,h = self.roads[str(neighbour_id)].planview.get_start_point()
                 h = (
                     h + np.pi
                 )  # we are attached to the predecessor's start, so road[k] will start in its opposite direction
+                relevant_lanesection = 0
+                relevant_s = 0
             elif contact_point == ContactPoint.end:
-                x, y, h = self.roads[str(neighbour_id)].planview.get_end_point()
+                x,y,h = self.roads[str(neighbour_id)].planview.get_end_point()
+                relevant_lanesection = -1
+                relevant_s = self.roads[str(neighbour_id)].planview.get_total_length()-self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].s
+
             else:
                 raise ValueError("Unknown ContactPoint")
             num_lane_offsets = main_road.lane_offset_suc
-            x = num_lane_offsets * 3 * np.sin(h) + x
-            y = -num_lane_offsets * 3 * np.cos(h) + y
-            main_road.planview.set_start_point(x, y, h)
+            offset_width = 0
+            #if a lane offset exists, go through relevant lanes to determine width of offset
+            if num_lane_offsets < 0 :
+                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].rightlanes[0:-1*num_lane_offsets]:
+                    offset_width = offset_width - (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
+            if num_lane_offsets > 0 :
+                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].leftlanes[0:num_lane_offsets]:
+                    offset_width = offset_width + lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3
+                    
+            x = offset_width*np.sin(h) + x
+            y = -offset_width*np.cos(h) + y
+            main_road.planview.set_start_point(x,y,h)
             main_road.planview.adjust_geometries(True)
 
     def adjust_startpoints(self):

--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -694,70 +694,61 @@ class OpenDrive:
         """
 
         main_road = self.roads[str(road_id)]
+        
+        if contact_point == ContactPoint.start :    
+            x,y,h = self.roads[str(neighbour_id)].planview.get_start_point()
+            h = (
+                h + np.pi
+            )  # we are attached to the predecessor's start, so road[k] will start in its opposite direction
+            relevant_lanesection = 0 # since we are at the start the first lane section is relevant for determining widths for lane offset
+            relevant_s = 0 # since we are at the start, the relevant s-coordinate for determining widths for lane offset is 0
+        elif contact_point == ContactPoint.end:
+            x,y,h = self.roads[str(neighbour_id)].planview.get_end_point()
+            relevant_lanesection = -1 # since we are at the end the last lane section is relevant for determining widths for lane offset
+            relevant_s = self.roads[str(neighbour_id)].planview.get_total_length()-self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].s 
+            # since we are at the end, the relevant s-coordinate for determining widths for lane offset is the length of the last lane section
+        else:
+            raise ValueError("Unknown ContactPoint")
 
         if neighbour_type == "predecessor":
 
-            if contact_point == ContactPoint.start :    
-                x,y,h = self.roads[str(neighbour_id)].planview.get_start_point()
-                h = (
-                    h + np.pi
-                )  # we are attached to the predecessor's start, so road[k] will start in its opposite direction
-                relevant_lanesection = 0
-                relevant_s = 0
-            elif contact_point == ContactPoint.end:
-                x,y,h = self.roads[str(neighbour_id)].planview.get_end_point()
-                relevant_lanesection = -1
-                relevant_s = self.roads[str(neighbour_id)].planview.get_total_length()-self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].s
-
-            else:
-                raise ValueError("Unknown ContactPoint")
-
             num_lane_offsets = main_road.lane_offset_pred
-            offset_width = 0
-            #if a lane offset exists, go through relevant lanes to determine width of offset
-            if num_lane_offsets < 0 :
-                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].rightlanes[0:-1*num_lane_offsets]:
-                    offset_width = offset_width - (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
-            if num_lane_offsets > 0 :
-                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].leftlanes[0:num_lane_offsets]:
-                    offset_width = offset_width + lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3
+            offset_width = self._calculate_lane_offset_width(neighbour_id, relevant_lanesection, relevant_s, num_lane_offsets)
             x = -offset_width*np.sin(h) + x
             y = offset_width*np.cos(h) + y
-
             main_road.planview.set_start_point(x,y,h)
             main_road.planview.adjust_geometries()
 
         elif neighbour_type == "successor":
 
-            if contact_point == ContactPoint.start:    
-                x,y,h = self.roads[str(neighbour_id)].planview.get_start_point()
-                h = (
-                    h + np.pi
-                )  # we are attached to the predecessor's start, so road[k] will start in its opposite direction
-                relevant_lanesection = 0
-                relevant_s = 0
-            elif contact_point == ContactPoint.end:
-                x,y,h = self.roads[str(neighbour_id)].planview.get_end_point()
-                relevant_lanesection = -1
-                relevant_s = self.roads[str(neighbour_id)].planview.get_total_length()-self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].s
-
-            else:
-                raise ValueError("Unknown ContactPoint")
             num_lane_offsets = main_road.lane_offset_suc
-            offset_width = 0
-            #if a lane offset exists, go through relevant lanes to determine width of offset
-            if num_lane_offsets < 0 :
-                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].rightlanes[0:-1*num_lane_offsets]:
-                    offset_width = offset_width - (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
-            if num_lane_offsets > 0 :
-                for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].leftlanes[0:num_lane_offsets]:
-                    offset_width = offset_width + lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3
-                    
+            offset_width = self._calculate_lane_offset_width(neighbour_id, relevant_lanesection, relevant_s, num_lane_offsets)
             x = offset_width*np.sin(h) + x
             y = -offset_width*np.cos(h) + y
             main_road.planview.set_start_point(x,y,h)
             main_road.planview.adjust_geometries(True)
+    
+    def _calculate_lane_offset_width(self, neighbour_id, relevant_lanesection, relevant_s, num_lane_offsets):
+        """calculate the width for shifting the road if a lane offset is present
 
+
+        Parameters
+        ----------
+        neighbour_id(int): id of the neighbour road we take as reference (we suppose the neighbour road is already adjusted)
+
+
+        """
+        #remains 0 if no lane offset exists        
+        offset_width = 0
+        #if a lane offset exists, loop through relevant lanes (left/right) at the relevant s-coordinate to determine width of offset
+        if num_lane_offsets < 0 :
+            for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].rightlanes[0:-1*num_lane_offsets]:
+                offset_width = offset_width - (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
+        if num_lane_offsets > 0 :
+            for lane in self.roads[str(neighbour_id)].lanes.lanesections[relevant_lanesection].leftlanes[0:num_lane_offsets]:
+                offset_width = offset_width + (lane.a + lane.b * relevant_s + lane.c * relevant_s**2 + lane.d * relevant_s**3)
+
+        return (offset_width)
     def adjust_startpoints(self):
         """Adjust starting position of all geoemtries of all roads
 


### PR DESCRIPTION
Hi there, I didn't make a PR in a while, but I ran into an issue when I tried creating a road with merges and splits. I needed to consider the lane_offset as in scenariogeneration\examples\xodr\highway_example_with_merge_and_split.py line 102 and 114. However, if I had lanes that are not 3m wide, the adjustment of the planview was wrong. I tried to avoid that magic number "3" and hope I got all the directions right. For my example it works, but maybe you can try check it and make more detailed tests? I also tried to clean up a bit by avoiding code duplication.