### PR TITLE
correct error message format

### DIFF
--- a/scenariogeneration/xosc/utils.py
+++ b/scenariogeneration/xosc/utils.py
@@ -1737,7 +1737,7 @@ class Catalog(VersionBase):
 
         if catalogname not in self._CATALOGS:
             raise ValueError(
-                "Not a correct catalog, approved catalogs are:" "".join(self._CATALOGS)
+                f"Not a correct catalog, approved catalogs are: {', '.join(self._CATALOGS)}."
             )
 
         self.catalogs[catalogname] = path


### PR DESCRIPTION
Corrected the error message format.

Old behaviour:
```
ValueError: VehicleCatalogNot a correct catalog, approved catalogs are:ControllerCatalogNot a correct catalog, approved catalogs are:PedestrianCatalogNot a correct catalog, approved catalogs are:MiscObjectCatalogNot a correct catalog, approved catalogs are:EnvironmentCatalogNot a correct catalog, approved catalogs are:ManeuverCatalogNot a correct catalog, approved catalogs are:TrajectoryCatalogNot a correct catalog, approved catalogs are:RouteCatalog
```

New behaviour:
```
ValueError: Not a correct catalog, approved catalogs are: VehicleCatalog, ControllerCatalog, PedestrianCatalog, MiscObjectCatalog, EnvironmentCatalog, ManeuverCatalog, TrajectoryCatalog, RouteCatalog.
```
