### PR TITLE
reverse order of element retrieval of leftlanes for descending lane ids

### DIFF
--- a/scenariogeneration/xodr/lane.py
+++ b/scenariogeneration/xodr/lane.py
@@ -281,7 +281,7 @@ class LaneSection:
 
         if self.leftlanes:
             left = ET.SubElement(element, "left")
-            for l in self.leftlanes:
+            for l in reversed(self.leftlanes):
                 left.append(l.get_element())
 
         center = ET.SubElement(element, "center")


### PR DESCRIPTION
According to the OpenDRIVE standard "In order to prevent confusion, lane records should represent the lanes from left to right (i.e. with descending ID)." Currently the left lanes are increasing, then we get the center lane and then we have decreasing right lanes. I reversed the output of leftlanes to fix this.