### PR TITLE
Make maxExecutionCount optional following the specification

### DIFF
--- a/scenariogeneration/xosc/storyboard.py
+++ b/scenariogeneration/xosc/storyboard.py
@@ -1112,7 +1112,7 @@ class Event(VersionBase):
 
         """
         name = element.attrib["name"]
-        maxexec = convert_int(element.attrib["maximumExecutionCount"])
+        maxexec = convert_int(element.get("maximumExecutionCount", 1))
         prio = getattr(Priority, element.attrib["priority"])
 
         event = Event(name, prio, maxexec)


### PR DESCRIPTION
As mentionied here:

https://www.asam.net/static_downloads/ASAM_OpenSCENARIO_V1.2.0_Model_Documentation/modelDocumentation/content/Event.html

The event has a default maximumExecutionCount of 1, therefore this field could be ommitted in osc files