### PR TITLE
Accept esmini arguments lacking trailing space

### DIFF
--- a/scenariogeneration/esmini_runner.py
+++ b/scenariogeneration/esmini_runner.py
@@ -160,7 +160,7 @@ def esmini(
     if timestep != None:
         additional_args += " --fixed_timestep " + str(timestep)
 
-    additional_args += " " + args + "--path " + resource_path
+    additional_args += " " + args + " --path " + resource_path
 
     # find executable based on OS
     if os.name == "posix":


### PR DESCRIPTION
Currently it seems like you need to add a trailing space after additional custom esmini args. This commit should fix so that esmini runner becomes slightly more tolerant.

e.g. accept `args="--clear-color 0,0,0"` as `well as args="--clear-color 0,0,0 "`

Full example:
`esmini(s, os.path.join('../esmini'), timestep=0.05, args="--clear-color 0,0,0")`