### PR TITLE
Fix overlaying repeating objects

### DIFF
--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -460,24 +460,31 @@ class Road:
             # retrieve lengths and widths of lane sections
             if idx == len(self.lanes.lanesections) - 1:
                 # last lanesection
-                lanesections_length.append(self.planview.get_total_length(
-                ) - lanesection.s)
+                lanesections_length.append(
+                    self.planview.get_total_length() - lanesection.s
+                )
 
             else:
-                lanesections_length.append(self.lanes.lanesections[idx + 1].s - lanesection.s)
+                lanesections_length.append(
+                    self.lanes.lanesections[idx + 1].s - lanesection.s
+                )
             lanesections_s.append(lanesection.s)
             if side != RoadSide.right:
                 # adding object for left side
                 road_objects[RoadSide.left] = cpy.deepcopy(road_object_prototype)
                 total_widths[RoadSide.left].append(0)
                 for lane in lanesection.leftlanes:
-                    total_widths[RoadSide.left][-1] = total_widths[RoadSide.left][-1] + lane.widths[0].a
+                    total_widths[RoadSide.left][-1] = (
+                        total_widths[RoadSide.left][-1] + lane.widths[0].a
+                    )
             if side != RoadSide.left:
                 # adding object for right side
                 road_objects[RoadSide.right] = cpy.deepcopy(road_object_prototype)
                 total_widths[RoadSide.right].append(0)
                 for lane in lanesection.rightlanes:
-                    total_widths[RoadSide.right][-1] = total_widths[RoadSide.right][-1] + lane.widths[0].a
+                    total_widths[RoadSide.right][-1] = (
+                        total_widths[RoadSide.right][-1] + lane.widths[0].a
+                    )
             # both sides are added if RoadSide.both
 
         for road_side in [RoadSide.left, RoadSide.right]:
@@ -489,23 +496,29 @@ class Road:
             hdg_factor = 1
             if road_side == RoadSide.right:
                 hdg_factor = -1
-            road_objects[road_side].t = (total_widths[road_side][0] + tOffset) * hdg_factor
+            road_objects[road_side].t = (
+                total_widths[road_side][0] + tOffset
+            ) * hdg_factor
             road_objects[road_side].hdg = np.pi * (1 + hdg_factor) / 2
             road_objects[road_side].s = sOffset
 
-            accumulated_length = 0          
+            accumulated_length = 0
             for idx, length in enumerate(lanesections_length):
-                accumulated_length += length                       
+                accumulated_length += length
                 if idx == 0:
-                    repeat_lengths[road_side].append(accumulated_length-sOffset)
+                    repeat_lengths[road_side].append(accumulated_length - sOffset)
                     repeat_s[road_side].append(sOffset)
-                    repeat_t[road_side].append((total_widths[road_side][idx] + tOffset) * hdg_factor)
+                    repeat_t[road_side].append(
+                        (total_widths[road_side][idx] + tOffset) * hdg_factor
+                    )
                 else:
-                    if total_widths[road_side][idx] != total_widths[road_side][idx-1]:
+                    if total_widths[road_side][idx] != total_widths[road_side][idx - 1]:
                         # add another repeat record only if width is changing
                         repeat_lengths[road_side].append(length)
                         repeat_s[road_side].append(lanesections_s[idx])
-                        repeat_t[road_side].append((total_widths[road_side][idx] + tOffset) * hdg_factor)
+                        repeat_t[road_side].append(
+                            (total_widths[road_side][idx] + tOffset) * hdg_factor
+                        )
                     else:
                         # otherwise add the length to existing repeat entry
                         repeat_lengths[road_side][-1] += length
@@ -515,7 +528,7 @@ class Road:
                     raise ValueError(
                         f"Calculated negative value for s-coordinate of roadside object with name "
                         f"'{road_objects[road_side].name}'. Ensure using sOffset < length of road."
-                               )
+                    )
                 road_objects[road_side].repeat(
                     repeat_length,
                     repeatDistance,
@@ -830,8 +843,8 @@ class OpenDrive:
                 offset_width = offset_width - (
                     lane.widths[relevant_lanesection].a
                     + lane.widths[relevant_lanesection].b * relevant_s
-                    + lane.widths[relevant_lanesection].c * relevant_s**2
-                    + lane.widths[relevant_lanesection].d * relevant_s**3
+                    + lane.widths[relevant_lanesection].c * relevant_s ** 2
+                    + lane.widths[relevant_lanesection].d * relevant_s ** 3
                 )
         if num_lane_offsets > 0:
             for lane in (
@@ -842,8 +855,8 @@ class OpenDrive:
                 offset_width = offset_width + (
                     lane.widths[relevant_lanesection].a
                     + lane.widths[relevant_lanesection].b * relevant_s
-                    + lane.widths[relevant_lanesection].c * relevant_s**2
-                    + lane.widths[relevant_lanesection].d * relevant_s**3
+                    + lane.widths[relevant_lanesection].c * relevant_s ** 2
+                    + lane.widths[relevant_lanesection].d * relevant_s ** 3
                 )
 
         return offset_width

--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -843,8 +843,8 @@ class OpenDrive:
                 offset_width = offset_width - (
                     lane.widths[relevant_lanesection].a
                     + lane.widths[relevant_lanesection].b * relevant_s
-                    + lane.widths[relevant_lanesection].c * relevant_s ** 2
-                    + lane.widths[relevant_lanesection].d * relevant_s ** 3
+                    + lane.widths[relevant_lanesection].c * relevant_s**2
+                    + lane.widths[relevant_lanesection].d * relevant_s**3
                 )
         if num_lane_offsets > 0:
             for lane in (
@@ -855,8 +855,8 @@ class OpenDrive:
                 offset_width = offset_width + (
                     lane.widths[relevant_lanesection].a
                     + lane.widths[relevant_lanesection].b * relevant_s
-                    + lane.widths[relevant_lanesection].c * relevant_s ** 2
-                    + lane.widths[relevant_lanesection].d * relevant_s ** 3
+                    + lane.widths[relevant_lanesection].c * relevant_s**2
+                    + lane.widths[relevant_lanesection].d * relevant_s**3
                 )
 
         return offset_width

--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -448,42 +448,80 @@ class Road:
                 "Could not add roadside object because roads and lanes need to be adjusted first. Consider calling 'adjust_roads_and_lanes()'."
             )
 
-        hdg_factors = []
-        total_widths = []
-        road_objects = []
-        s_lanesections = []
+        total_widths = {RoadSide.right: [], RoadSide.left: []}
+        road_objects = {RoadSide.right: None, RoadSide.left: None}
+        repeat_lengths = {RoadSide.right: [], RoadSide.left: []}
+        repeat_s = {RoadSide.right: [], RoadSide.left: []}
+        lanesections_s = []
+        lanesections_length = []
         # TODO: handle width parameters apart from a
-        for lanesection in self.lanes.lanesections:
+        for idx, lanesection in enumerate(self.lanes.lanesections):
+            # retrieve lengths and widths of lane sections
+            if idx == len(self.lanes.lanesections) - 1:
+                # last lanesection
+                lanesections_length.append(self.planview.get_total_length(
+                ) - lanesection.s)
+                
+            else:
+                lanesections_length.append(self.lanes.lanesections[idx + 1].s - lanesection.s)
+            lanesections_s.append(lanesection.s)
             if side != RoadSide.right:
-                s_lanesections.append(lanesection.s)
-                hdg_factors.append(1)
-                total_widths.append(0)
-                road_objects.append(cpy.deepcopy(road_object_prototype))
+                # adding object for left side
+                road_objects[RoadSide.left] = cpy.deepcopy(road_object_prototype)
+                total_widths[RoadSide.left].append(0)
                 for lane in lanesection.leftlanes:
-                    total_widths[-1] = total_widths[-1] + lane.widths[0].a
+                    total_widths[RoadSide.left][-1] = total_widths[RoadSide.left][-1] + lane.widths[0].a
             if side != RoadSide.left:
-                s_lanesections.append(lanesection.s)
-                hdg_factors.append(-1)
-                total_widths.append(0)
-                road_objects.append(cpy.deepcopy(road_object_prototype))
+                # adding object for right side
+                road_objects[RoadSide.right] = cpy.deepcopy(road_object_prototype)
+                total_widths[RoadSide.right].append(0)
                 for lane in lanesection.rightlanes:
-                    total_widths[-1] = total_widths[-1] + lane.widths[0].a
+                    total_widths[RoadSide.right][-1] = total_widths[RoadSide.right][-1] + lane.widths[0].a
+            # both sides are added if RoadSide.both
 
-        for idx, road_object in enumerate(road_objects):
-            road_object.t = (total_widths[idx] + tOffset) * hdg_factors[idx]
-            road_object.s = sOffset + s_lanesections[idx]
-            road_object.hdg = np.pi * (1 + hdg_factors[idx]) / 2
-            road_object.repeat(
-                self.planview.get_total_length() - sOffset - s_lanesections[idx],
-                repeatDistance,
-                widthStart=widthStart,
-                widthEnd=widthEnd,
-                lengthStart=lengthStart,
-                lengthEnd=lengthEnd,
-                radiusStart=radiusStart,
-                radiusEnd=radiusEnd,
-            )
-        self.add_object(road_objects)
+        for road_side in [RoadSide.left, RoadSide.right]:
+            if road_objects[road_side] == None:
+                # no road_object is added to this roadside
+                continue
+            
+            # initialize road objects with meaningful values
+            hdg_factor = 1
+            if road_side == RoadSide.right:
+                hdg_factor = -1
+            road_objects[road_side].t = (total_widths[road_side][0] + tOffset) * hdg_factor
+            road_objects[road_side].hdg = np.pi * (1 + hdg_factor) / 2
+            road_objects[road_side].s = sOffset
+            
+            accumulated_length = 0          
+            for idx, length in enumerate(lanesections_length):
+                accumulated_length += length                       
+                if idx == 0:
+                    repeat_lengths[road_side].append(accumulated_length-sOffset)
+                    repeat_s[road_side].append(sOffset)
+                else:
+                    if total_widths[road_side][idx] != total_widths[road_side][idx-1]:
+                        # add another repeat record only if width is changing
+                        repeat_lengths[road_side].append(length)
+                        repeat_s[road_side].append(lanesections_s[idx])
+                    else:
+                        # otherwise add the length to existing repeat entry
+                        repeat_lengths[road_side][-1]+=length
+
+            for idx, repeat in enumerate(repeat_lengths[road_side]):
+                road_objects[road_side].repeat(
+                    repeat_lengths[road_side][idx],
+                    repeatDistance,
+                    sStart=None,
+                    tStart=(total_widths[road_side][0] + tOffset) * hdg_factor,
+                    tEnd=(total_widths[road_side][0] + tOffset) * hdg_factor,
+                    widthStart=widthStart,
+                    widthEnd=widthEnd,
+                    lengthStart=lengthStart,
+                    lengthEnd=lengthEnd,
+                    radiusStart=radiusStart,
+                    radiusEnd=radiusEnd,
+                )
+            self.add_object(road_objects[road_side])
         return self
 
     def add_signal(self, signal):


### PR DESCRIPTION
- make sure s and length of repeat entries are used correctly for roads with multiple lane sections
- use multiple repeat entries for one object instead of multiple objects with one repeat entry