### PR TITLE
Fix edge case for connecting road in lanesection getter

### DIFF
--- a/scenariogeneration/xodr/links.py
+++ b/scenariogeneration/xodr/links.py
@@ -917,14 +917,19 @@ def _get_related_lanesection(road, connected_road):
 
     if connected_road.road_type != -1:
         # treat connecting road in junction differently
-        if connected_road.predecessor.element_id == road.id:
+        if (
+            connected_road.predecessor
+            and connected_road.predecessor.element_id == road.id
+        ):
             if connected_road.predecessor.contact_point == ContactPoint.start:
                 road_lanesection_id = 0
                 sign = -1
             else:
                 road_lanesection_id = -1
                 sign = 1
-        elif connected_road.successor.element_id == road.id:
+        elif (
+            connected_road.successor and connected_road.successor.element_id == road.id
+        ):
             if connected_road.successor.contact_point == ContactPoint.start:
                 road_lanesection_id = 0
                 sign = 1


### PR DESCRIPTION
This could previously crash if a connecting road was only connected to one road, e.g., due to the outgoing road still not being constructed.

I just added the
`if connected_road.predecessor:`
and
`if connected_road.successor:`