### PR TITLE
Fixed typo

### DIFF
--- a/scenariogeneration/xosc/actions.py
+++ b/scenariogeneration/xosc/actions.py
@@ -2211,7 +2211,7 @@ class ActivateControllerAction(_PrivateActionType):
         animation = None
         lighting = None
         controllerRef = None
-        aca_element = element.find("ControllerAction/ActivateControllerAction")
+        aca_element = element.find("ActivateControllerAction")
         if "lateral" in aca_element.attrib:
             lateral = convert_bool(aca_element.attrib["lateral"])
         if "longitudinal" in aca_element.attrib:


### PR DESCRIPTION
Typo, here .xosc file: 
          <PrivateAction>
            <ActivateControllerAction lateral="true" longitudinal="true" />
          </PrivateAction>