### PR TITLE
Fix order of links to comply to schema

### DIFF
--- a/scenariogeneration/xodr/links.py
+++ b/scenariogeneration/xodr/links.py
@@ -157,7 +157,9 @@ class _Links:
         """returns the elementTree of the _Link"""
 
         element = ET.Element("link")
-        for l in self.links:
+        # sort links alphabetically by link type to ensure predecessor 
+        # appears before successor to comply to schema
+        for l in sorted(self.links, key=lambda x: x.link_type):
             element.append(l.get_element())
         return element
 

--- a/scenariogeneration/xodr/links.py
+++ b/scenariogeneration/xodr/links.py
@@ -157,7 +157,7 @@ class _Links:
         """returns the elementTree of the _Link"""
 
         element = ET.Element("link")
-        # sort links alphabetically by link type to ensure predecessor 
+        # sort links alphabetically by link type to ensure predecessor
         # appears before successor to comply to schema
         for l in sorted(self.links, key=lambda x: x.link_type):
             element.append(l.get_element())


### PR DESCRIPTION
- sort links by type (predecessor before successor) to ensure schema compliance
- not relevant for most applications, just to avoid schema validation errors