### PR TITLE
Fix parsing of trajectory parameters

### DIFF
--- a/scenariogeneration/xosc/position.py
+++ b/scenariogeneration/xosc/position.py
@@ -24,6 +24,7 @@ from .exceptions import (
 from .utils import (
     CatalogReference,
     Orientation,
+    ParameterDeclarations,
     VersionBase,
     _BaseCatalog,
     _PositionType,
@@ -2616,8 +2617,11 @@ class Trajectory(_BaseCatalog):
         closed = convert_bool(element.attrib["closed"])
         pos_element = find_mandatory_field(element, "Shape")
         shape = _ShapeFactory.parse_shape(pos_element)
+        params = ParameterDeclarations.parse(element.find("ParameterDeclarations"))
         trajectory = Trajectory(name, closed)
         trajectory.add_shape(shape)
+        for param in params.parameters:
+            trajectory.add_parameter(param)
         return trajectory
 
     def add_shape(self, shape: _TrajectoryShape) -> "Trajectory":


### PR DESCRIPTION
As explained in issue #274, the `Trajectory()` class only takes care of its parameters when exporting the XML element, but forgets about them when parsing an XML element. Therefore, I added a few lines of code that create a `ParameterDeclarations()` object, populates it with the parameters and adds it to the `Trajectory()`. In the linked issue, you can find example code to test this PR.