### PR TITLE
Include the schemas folder in the wheel distribution.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages=["scenariogeneration","scenariogeneration.xosc","scenariogeneration.xodr"]
+include-package-data = true
 
+[tool.setuptools.package-data]
+scenariogeneration = ["../schemas/*.xsd"]
 
 [project]
 name = "scenariogeneration" # REQUIRED, is the only field that cannot be marked as dynamic.

--- a/scenariogeneration/xosc/xosc_reader.py
+++ b/scenariogeneration/xosc/xosc_reader.py
@@ -244,7 +244,7 @@ def validate_schema(loaded_xosc: ET.ElementTree) -> bool:
     if minor_version == "3" and major_version == "1":
         minor_version = "3_1"
     xsd_path = os.path.join(
-        Path.cwd(),
+        Path(__file__).parent.parent.parent,
         "schemas",
         "OpenSCENARIO_" + major_version + "_" + minor_version + ".xsd",
     )


### PR DESCRIPTION
We used schemas for validation in the code, but they were not included in the wheel package, which caused  failures for users .