### PR TITLE
Add missing reference elements for signals and objects

### DIFF
--- a/scenariogeneration/xodr/opendrive.py
+++ b/scenariogeneration/xodr/opendrive.py
@@ -47,7 +47,13 @@ from .geometry import AdjustablePlanview, PlanView, Spiral
 from .lane import Lanes
 from .lane_def import LaneDef, create_lanes_merge_split, std_roadmark_solid
 from .links import Junction, _Link, _Links, create_lane_links
-from .signals_objects import Object, Signal, SignalReference, Tunnel
+from .signals_objects import (
+    Object,
+    ObjectReference,
+    Signal,
+    SignalReference,
+    Tunnel,
+)
 from .utils import XodrBase, get_lane_sec_and_s_for_lane_calc
 
 
@@ -572,14 +578,20 @@ class Road(XodrBase):
         self._shape_adjusted = True
         return self
 
-    def add_object(self, road_object: Union[Object, list[Object]]) -> "Road":
-        """Add an object or a list of objects to the road and ensure unique
-        IDs.
+    def add_object(
+        self,
+        road_object: Union[
+            Object,
+            ObjectReference,
+            list[Union[Object, ObjectReference]],
+        ],
+    ) -> "Road":
+        """Add an object reference, object, or list of them to the road.
 
         Parameters
         ----------
-        road_object : Object or list[Object]
-            The object(s) to be added to the road.
+        road_object : Object, ObjectReference, or list[Object or ObjectReference]
+            The object-related element(s) to be added to the road.
 
         Returns
         -------
@@ -589,21 +601,26 @@ class Road(XodrBase):
         Raises
         ------
         TypeError
-            If `road_object` or any element in the list is not of type `Object`.
+            If `road_object` or any element in the list is not of type
+            `Object` or `ObjectReference`.
         """
         if isinstance(road_object, list):
             for single_object in road_object:
-                if not isinstance(single_object, Object):
+                if not isinstance(single_object, (Object, ObjectReference)):
                     raise TypeError(
-                        "road_object contains elements that are not of type Object"
+                        "road_object contains elements that are not of type Object or ObjectReference"
                     )
-                single_object._update_id()
+                if isinstance(single_object, Object):
+                    single_object._update_id()
 
             self.objects = self.objects + road_object
         else:
-            if not isinstance(road_object, Object):
-                raise TypeError("road_object is not of type Object")
-            road_object._update_id()
+            if not isinstance(road_object, (Object, ObjectReference)):
+                raise TypeError(
+                    "road_object is not of type Object or ObjectReference"
+                )
+            if isinstance(road_object, Object):
+                road_object._update_id()
             self.objects.append(road_object)
         return self
 

--- a/scenariogeneration/xodr/signals_objects.py
+++ b/scenariogeneration/xodr/signals_objects.py
@@ -406,10 +406,15 @@ class Signal(_SignalObjectBase):
         self.unit = unit
         self.hOffset = hOffset
         self.validity = None
+        self.references = []
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Signal) and super().__eq__(other):
-            if self.get_attributes() == other.get_attributes():
+            if (
+                self.get_attributes() == other.get_attributes()
+                and self.validity == other.validity
+                and self.references == other.references
+            ):
                 return True
         return False
 
@@ -463,6 +468,29 @@ class Signal(_SignalObjectBase):
         self.validity = Validity(fromLane, toLane)
         return self
 
+    def add_reference(self, reference: "Reference") -> "Signal":
+        """Add a reference entry to the Signal.
+
+        Parameters
+        ----------
+        reference : Reference
+            The reference to add.
+
+        Returns
+        -------
+        Signal
+            The updated Signal object.
+
+        Raises
+        ------
+        TypeError
+            If `reference` is not of type Reference.
+        """
+        if not isinstance(reference, Reference):
+            raise TypeError("reference is not of type Reference")
+        self.references.append(reference)
+        return self
+
     def get_element(self) -> ET.Element:
         """Return the ElementTree representation of the Signal.
 
@@ -475,6 +503,8 @@ class Signal(_SignalObjectBase):
         self._add_additional_data_to_element(element)
         if self.validity:
             element.append(self.validity.get_element())
+        for reference in self.references:
+            element.append(reference.get_element())
         return element
 
 
@@ -602,6 +632,223 @@ class Dependency(XodrBase):
         """
         element = ET.Element("dependency", attrib=self.get_attributes())
         self._add_additional_data_to_element(element)
+        return element
+
+
+class Reference(XodrBase):
+    """Reference defines the reference element in OpenDRIVE.
+
+    It is placed within the signal element and links the signal to another
+    signal or object. This class maps to `<signal>/<reference>` as defined
+    in OpenDRIVE signal reference and is distinct from
+    `<objects>/<objectReference>`.
+
+    Attributes
+    ----------
+    element_id : str
+        Unique ID of the linked element.
+    element_type : str
+        Type of the linked element.
+    type : str, optional
+        Type of the linkage.
+
+    Methods
+    -------
+    get_element()
+        Returns the full ElementTree representation of the Reference.
+    get_attributes()
+        Returns a dictionary of all attributes of the Reference.
+    """
+
+    def __init__(
+        self,
+        element_id: str,
+        element_type: str,
+        type: Optional[str] = None,
+    ) -> None:
+        """Initialize the Reference.
+
+        Parameters
+        ----------
+        element_id : str
+            Unique ID of the linked element.
+        element_type : str
+            Type of the linked element.
+        type : str, optional
+            Type of the linkage. Default is None.
+        """
+        super().__init__()
+        self.element_id = element_id
+        self.element_type = element_type
+        self.type = type
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Reference) and super().__eq__(other):
+            if self.get_attributes() == other.get_attributes():
+                return True
+        return False
+
+    def get_attributes(self) -> dict[str, str]:
+        """Return the attributes of the Reference as a dictionary.
+
+        Returns
+        -------
+        dict[str, str]
+            A dictionary containing the attributes of the Reference.
+        """
+        retdict = {
+            "elementId": str(self.element_id),
+            "elementType": str(self.element_type),
+        }
+        if self.type is not None:
+            retdict["type"] = str(self.type)
+        return retdict
+
+    def get_element(self) -> ET.Element:
+        """Return the ElementTree representation of the Reference.
+
+        Returns
+        -------
+        ET.Element
+            The XML ElementTree representation of the Reference.
+        """
+        element = ET.Element("reference", attrib=self.get_attributes())
+        self._add_additional_data_to_element(element)
+        return element
+
+
+class ObjectReference(XodrBase):
+    """ObjectReference defines the objectReference element in OpenDRIVE.
+
+    It is placed within the objects element and links one object across
+    multiple roads.
+
+    Attributes
+    ----------
+    s : float
+        s-coordinate of the ObjectReference.
+    t : float
+        t-coordinate of the ObjectReference.
+    id : str
+        Unique ID of the referred object.
+    orientation : Orientation
+        Orientation of the object reference with respect to the road.
+    validLength : float, optional
+        Validity of the object reference along s-axis.
+    zOffset : float, optional
+        Vertical offset of object reference with respect to centerline.
+    validity : Validity, optional
+        Explicit lane validity information for the object reference.
+    """
+
+    def __init__(
+        self,
+        s: float,
+        t: float,
+        id: str,
+        orientation: Orientation = Orientation.none,
+        validLength: Optional[float] = None,
+        zOffset: Optional[float] = None,
+    ) -> None:
+        """Initialize the ObjectReference.
+
+        Parameters
+        ----------
+        s : float
+            s-coordinate of the ObjectReference.
+        t : float
+            t-coordinate of the ObjectReference.
+        id : str
+            Unique ID of the referred object.
+        orientation : Orientation, optional
+            Orientation of the ObjectReference with respect to the road.
+            Default is Orientation.none.
+        validLength : float, optional
+            Validity of the object reference along s-axis. Default is None.
+        zOffset : float, optional
+            Vertical offset of the object reference. Default is None.
+        """
+        super().__init__()
+        self.s = s
+        self.t = t
+        self.id = id
+        self.orientation = enumchecker(orientation, Orientation)
+        self.validLength = validLength
+        self.zOffset = zOffset
+        self.validity = None
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ObjectReference) and super().__eq__(other):
+            if (
+                self.get_attributes() == other.get_attributes()
+                and self.validity == other.validity
+            ):
+                return True
+        return False
+
+    def add_validity(self, fromLane: int, toLane: int) -> "ObjectReference":
+        """Add a validity range to the ObjectReference.
+
+        Parameters
+        ----------
+        fromLane : int
+            The starting lane for the validity range.
+        toLane : int
+            The ending lane for the validity range.
+
+        Returns
+        -------
+        ObjectReference
+            The updated ObjectReference object.
+
+        Raises
+        ------
+        ValueError
+            If a validity range is already set for the ObjectReference.
+        """
+        if self.validity:
+            raise ValueError("only one validity is allowed")
+        self.validity = Validity(fromLane, toLane)
+        return self
+
+    def get_attributes(self) -> dict[str, str]:
+        """Return the attributes of the ObjectReference as a dictionary.
+
+        Returns
+        -------
+        dict[str, str]
+            A dictionary containing the attributes of the ObjectReference.
+        """
+        retdict = {
+            "id": str(self.id),
+            "s": str(self.s),
+            "t": str(self.t),
+        }
+        if self.orientation == Orientation.positive:
+            retdict["orientation"] = "+"
+        elif self.orientation == Orientation.negative:
+            retdict["orientation"] = "-"
+        else:
+            retdict["orientation"] = enum2str(self.orientation)
+
+        if self.validLength is not None:
+            retdict["validLength"] = str(self.validLength)
+        if self.zOffset is not None:
+            retdict["zOffset"] = str(self.zOffset)
+        return retdict
+
+    def get_element(self) -> ET.Element:
+        """Return the ElementTree representation of the ObjectReference.
+
+        Returns
+        -------
+        ET.Element
+            The XML ElementTree representation of the ObjectReference.
+        """
+        element = ET.Element("objectReference", attrib=self.get_attributes())
+        self._add_additional_data_to_element(element)
+        if self.validity:
+            element.append(self.validity.get_element())
         return element
 
 

--- a/tests/test_signals_objects.py
+++ b/tests/test_signals_objects.py
@@ -193,6 +193,89 @@ def test_signal_reference():
         xodr.SignalReference(1, 1, 1, "dummy")
 
 
+def test_signal_reference_element():
+    signal = xodr.Signal(
+        s=10.0,
+        t=-2,
+        dynamic=xodr.Dynamic.no,
+        orientation=xodr.Orientation.positive,
+        zOffset=0.00,
+        country="US",
+        Type="R1",
+        subtype="1",
+    )
+
+    reference = xodr.Reference(
+        element_id="7",
+        element_type="signal",
+        type="stopline",
+    )
+    signal.add_reference(reference)
+
+    road = xodr.create_road(xodr.Line(100), 0)
+    road.add_signal(signal)
+    prettyprint(road.get_element())
+
+    assert (
+        version_validation(
+            "t_road_signals_signal", signal, wanted_schema="xodr"
+        )
+        == ValidationResponse.OK
+    )
+
+    signal_element = signal.get_element()
+    reference_elements = signal_element.findall("reference")
+    assert len(reference_elements) == 1
+    assert reference_elements[0].attrib["elementId"] == "7"
+    assert reference_elements[0].attrib["elementType"] == "signal"
+    assert reference_elements[0].attrib["type"] == "stopline"
+
+    with pytest.raises(TypeError):
+        signal.add_reference("dummy")
+
+
+def test_object_reference_element():
+    object_reference = xodr.ObjectReference(
+        s=13.1,
+        t=0.0,
+        id="7",
+        orientation=xodr.Orientation.negative,
+        validLength=0.0,
+        zOffset=0.0,
+    )
+    object_reference.add_validity(-1, -1)
+
+    road = xodr.create_road(xodr.Line(100), 0)
+    road.add_object(object_reference)
+    prettyprint(road.get_element())
+    road.planview.adjust_geometries()
+
+    assert (
+        version_validation("t_road", road, wanted_schema="xodr")
+        == ValidationResponse.OK
+    )
+
+    road_element = road.get_element()
+    object_reference_elements = road_element.findall(
+        "./objects/objectReference"
+    )
+    assert len(object_reference_elements) == 1
+    assert object_reference_elements[0].attrib["id"] == "7"
+    assert object_reference_elements[0].attrib["orientation"] == "-"
+    assert object_reference_elements[0].attrib["s"] == "13.1"
+    assert object_reference_elements[0].attrib["t"] == "0.0"
+    assert object_reference_elements[0].attrib["validLength"] == "0.0"
+    assert object_reference_elements[0].attrib["zOffset"] == "0.0"
+
+    validity = object_reference_elements[0].find("validity")
+    assert validity is not None
+    assert validity.attrib["fromLane"] == "-1"
+    assert validity.attrib["toLane"] == "-1"
+
+    with pytest.raises(ValueError):
+        object_reference.add_validity(1, 1)
+
+
 def test_object():
     object1 = xodr.Object(
         s=10.0,


### PR DESCRIPTION
It is not possible to completely build the example here (scroll down)
https://publications.pages.asam.net/standards/ASAM_OpenDRIVE/ASAM_OpenDRIVE_Specification/v1.9.0/specification/14_signals/14_04_signal_reference.html
This PR aims to fix that.
